### PR TITLE
Improvements and documentation

### DIFF
--- a/CrossAccountSlaveRoles.yml
+++ b/CrossAccountSlaveRoles.yml
@@ -1,0 +1,48 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: |
+  Creates roles for Jenkins slave tasks. This is meant to be used when ECR resides in a different account where Jenkins
+  resides
+Parameters:
+  ECRRoleArn:
+    Description: The cross account Role for ECR push access
+    Type: String
+  JenkinsCacheBucket:
+    Description: The name of the jenkins cache bucket
+    Type: String  
+Resources:
+  JenkinsSlaveRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: JenkinsSlaveRole
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Sid: ''
+          Effect: Allow
+          Principal:
+            Service: ecs-tasks.amazonaws.com
+          Action: sts:AssumeRole
+      Path: /
+      Policies:
+      - PolicyName: JenkinsSlaveECRPolicy
+        PolicyDocument:
+          Statement:
+          - Sid: Stmt1452746887373
+            Effect: Allow
+            Action: sts:AssumeRole
+            Resource: !Ref 'ECRRoleArn'
+      - PolicyName: JenkinsSlaveS3Cache
+        PolicyDocument:
+          Statement:  
+          - Effect: Allow
+            Action:
+            - s3:GetObject
+            Resource: !Sub 'arn:aws:s3:::${JenkinsCacheBucket}/*'
+          - Effect: Allow
+            Action:
+            - s3:ListBucket
+            Resource: !Sub 'arn:aws:s3:::${JenkinsCacheBucket}'
+Outputs:
+  TaskRoleArn:
+    Description: The ARN of the jenkins slave role
+    Value: !GetAtt JenkinsSlaveRole.Arn

--- a/ECSJenkins.yml
+++ b/ECSJenkins.yml
@@ -64,10 +64,45 @@ Parameters:
     Type: Number
     Description: The minimum CPU units reserved for jenkins master. (1000 = 1 core)
     Default: '1000'
+  JenkinsMasterDockerImage:
+    Type: String
+    Description: The Docker image to use for the Jenkins master (resides on Docker Hub)
+    Default: 'loyaltyone/jenkins'
   LoadBalancerIdleTimeout:
     Type: Number
     Description: The time in seconds the ELB will keep idle connections active. Increase this if you see intermittent disconnects of slaves
     Default: '180'
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: 'General'
+        Parameters:
+          - ClusterStackName
+          - TimeZone
+      - Label:
+          default: 'Jenkins Master ECS specifications'
+        Parameters:
+          - Cpu
+          - Memory
+          - JenkinsMasterDockerImage
+      - Label:
+          default: 'Network'
+        Parameters:
+          - SubnetIds
+          - AllowedCidr
+          - HostedZoneName
+          - CertificateArn
+          - LoadBalancerIdleTimeout
+      - Label:
+          default: 'Backups and logs'
+        Parameters:
+          - MasterLogRetention
+          - SlaveLogRetention
+          - SetupKinesisSubscriptionFilter
+          - KinesisStackName
+          - S3BackupBucketExists
+          - S3BackupBucketName
 Conditions:
   CreateS3Bucket: !Equals [!Ref 'S3BackupBucketExists', 'no']
   CreateSubscriptionFilter: !Equals [!Ref 'SetupKinesisSubscriptionFilter', 'yes']
@@ -199,7 +234,7 @@ Resources:
     Properties:
       ContainerDefinitions:
       - Name: jenkins
-        Image: loyaltyone/jenkins
+        Image: !Ref 'JenkinsMasterDockerImage'
         Hostname: jenkins
         Cpu: !Ref 'Cpu'
         MemoryReservation: !Ref 'Memory'

--- a/ECSJenkins.yml
+++ b/ECSJenkins.yml
@@ -32,7 +32,14 @@ Parameters:
   CertificateArn:
     Type: String
     Description: The ARN of a certificate to attach to the Load Balancer.
-  KinesisStackName: 
+  SetupKinesisSubscriptionFilter:
+    Type: String
+    Description: Controls the creation of the subscription filter resource based on the KinesisStackName
+    Default: 'no'
+    AllowedValues:
+    - 'yes'
+    - 'no'
+  KinesisStackName:
     Type: String
     Description: The name of an existing Kinesis Stack used for streaming logs from cloudwatch to another destination
   S3BackupBucketExists:
@@ -63,6 +70,7 @@ Parameters:
     Default: '180'
 Conditions:
   CreateS3Bucket: !Equals [!Ref 'S3BackupBucketExists', 'no']
+  CreateSubscriptionFilter: !Equals [!Ref 'SetupKinesisSubscriptionFilter', 'yes']
 Resources:
   ELBSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -272,6 +280,7 @@ Resources:
     Type: AWS::Logs::SubscriptionFilter
     DependsOn:
     - MasterLogGroup
+    Condition: CreateSubscriptionFilter
     Properties:
       RoleArn: !ImportValue
         Fn::Sub: ${KinesisStackName}-Role-Arn

--- a/ECSJenkins.yml
+++ b/ECSJenkins.yml
@@ -240,7 +240,7 @@ Resources:
         MemoryReservation: !Ref 'Memory'
         Environment:
         - Name: JAVA_OPTS
-          Value: !Sub '-Djenkins.install.runSetupWizard=false -Dorg.apache.commons.jelly.tags.fmt.timeZone=${TimeZone}'
+          Value: !Sub '-Djenkins.install.runSetupWizard=false -Dorg.apache.commons.jelly.tags.fmt.timeZone=${TimeZone} -Dhudson.slaves.NodeProvisioner.MARGIN=50 -Dhudson.slaves.NodeProvisioner.MARGIN0=0.85'
         # We will run as this user (docker-user) 
         - Name: LOCAL_USER_ID
           Value: 5001

--- a/LocalSlaveRoles.yml
+++ b/LocalSlaveRoles.yml
@@ -6,6 +6,9 @@ Parameters:
   JenkinsCacheBucket:
     Description: The name of the jenkins cache bucket
     Type: String
+  JenkinsArtifactBucket:
+    Description: The name of the jenkins artifact bucket (i.e. JARs)
+    Type: String
 Resources:
   JenkinsSlaveRole:
     Type: AWS::IAM::Role
@@ -49,6 +52,18 @@ Resources:
             Action:
             - s3:ListBucket
             Resource: !Sub 'arn:aws:s3:::${JenkinsCacheBucket}'
+      - # This IAM policy is temporary (remove once we stop storing Maven/Ivy2 artifacts are not stored in S3)
+        PolicyName: JenkinsSlaveS3Artifact
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action:
+            - s3:GetObject
+            Resource: !Sub 'arn:aws:s3:::${JenkinsArtifactBucket}/*'
+          - Effect: Allow
+            Action:
+            - s3:ListBucket
+            Resource: !Sub 'arn:aws:s3:::${JenkinsArtifactBucket}'
 
 Outputs:
   TaskRoleArn:

--- a/LocalSlaveRoles.yml
+++ b/LocalSlaveRoles.yml
@@ -1,10 +1,8 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: |
-  Creates roles for jenkins slave tasks. This is meant to be used when ECR resides in the same account as Jenkins
+  Creates roles for jenkins slave tasks. This is meant to be used when ECR resides in the same account as Jenkins.
+  This will allow Jenkins slaves that use this IAM role to push to any ECR repository in the same AWS account.
 Parameters:
-  ECRRepoArn:
-    Description: The ECR ARN if ECR resides in the same account as Jenkins (and not in another account)
-    Type: String
   JenkinsCacheBucket:
     Description: The name of the jenkins cache bucket
     Type: String
@@ -29,13 +27,13 @@ Resources:
           - Effect: Allow
             Action:
               - ecr:*
-            Resource: !Ref 'ECRRepoArn'
+            Resource: !Sub 'arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/*'
           - Effect: Deny
             Action:
               - ecr:BatchDeleteImage
               - ecr:DeleteRepositoryPolicy
               - ecr:SetRepositoryPolicy
-            Resource: !Ref 'ECRRepoArn'
+            Resource: !Sub 'arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/*'
       - PolicyName: JenkinsSlaveS3Cache
         PolicyDocument:
           Statement:

--- a/LocalSlaveRoles.yml
+++ b/LocalSlaveRoles.yml
@@ -34,6 +34,10 @@ Resources:
               - ecr:DeleteRepositoryPolicy
               - ecr:SetRepositoryPolicy
             Resource: !Sub 'arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/*'
+          - Effect: Allow
+            Action:
+              - ecr:GetAuthorizationToken
+            Resource: '*'
       - PolicyName: JenkinsSlaveS3Cache
         PolicyDocument:
           Statement:

--- a/LocalSlaveRoles.yml
+++ b/LocalSlaveRoles.yml
@@ -1,12 +1,13 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: Creates roles for jenkins slave tasks
+Description: |
+  Creates roles for jenkins slave tasks. This is meant to be used when ECR resides in the same account as Jenkins
 Parameters:
-  ECRRoleArn:
-    Description: The cross account Role for ECR push access
+  ECRRepoArn:
+    Description: The ECR ARN if ECR resides in the same account as Jenkins (and not in another account)
     Type: String
   JenkinsCacheBucket:
     Description: The name of the jenkins cache bucket
-    Type: String  
+    Type: String
 Resources:
   JenkinsSlaveRole:
     Type: AWS::IAM::Role
@@ -22,16 +23,22 @@ Resources:
           Action: sts:AssumeRole
       Path: /
       Policies:
-      - PolicyName: JenkinsSlaveECRPolicy
+      - PolicyName: JenkinsSlaveECRLocalPolicy
         PolicyDocument:
           Statement:
-          - Sid: Stmt1452746887373
-            Effect: Allow
-            Action: sts:AssumeRole
-            Resource: !Ref 'ECRRoleArn'
+          - Effect: Allow
+            Action:
+              - ecr:*
+            Resource: !Ref 'ECRRepoArn'
+          - Effect: Deny
+            Action:
+              - ecr:BatchDeleteImage
+              - ecr:DeleteRepositoryPolicy
+              - ecr:SetRepositoryPolicy
+            Resource: !Ref 'ECRRepoArn'
       - PolicyName: JenkinsSlaveS3Cache
         PolicyDocument:
-          Statement:  
+          Statement:
           - Effect: Allow
             Action:
             - s3:GetObject
@@ -40,6 +47,7 @@ Resources:
             Action:
             - s3:ListBucket
             Resource: !Sub 'arn:aws:s3:::${JenkinsCacheBucket}'
+
 Outputs:
   TaskRoleArn:
     Description: The ARN of the jenkins slave role

--- a/README.md
+++ b/README.md
@@ -7,13 +7,32 @@ This template depends on the creation of an ECS cluster using [ECSCluster](https
 Once an ECS cluster has been created with the linked template, the stack name should be provided as input to this `ECSJenkins.template`
 
 The ECS cluster should also be using an EFS mount [EFS Mount Template](https://github.com/ukayani/ecs-cluster#efswithmounttargettemplate)
- 
-The Jenkins slaves can be optimized to fetch cache data (eg. to avoid unnecessary network traffic especially for 
-Scala/SBT projects) and also push Docker images to ECR (which may not reside in the same account). You can enable these
-features by executing the [SlaveRoles](SlaveRoles.yml) CloudFormation template. 
 
-**Note:** that you need to specify the ARN for the IAM role that allows publishing Docker images to ECR to the 
-[SlaveRoles](SlaveRoles.yml) CloudFormation template. 
+### ECR ###
+ 
+If you plan on using Docker images in conjunction with Jenkins, AWS ECR is an excellent choice as a Container Registry
+where you can store private Docker images. A common practice is to have Jenkins slaves build Docker images and push 
+these images to ECR as part of the Continuous Delivery process. In order to do this, you need to have the correct IAM 
+roles and permissions set up for this to work. 
+
+#### ECR resides in a different account from Jenkins ####
+
+The [ECRCrossAccountRole](ECRCrossAccountRole.yml) should be used when 
+your AWS ECR repository is in another account. Execute [ECRCrossAccountRole](ECRCrossAccountRole.yml) on the account
+where ECR is hosted (call this Account X) and specify the AWS Account ID which will be able to push images to 
+(call this Account Y). This will generate an IAM Role ARN that can be used in Account Y to publish ECR images to 
+Account X.
+
+The Jenkins slaves (run as ECS tasks) will push Docker images to ECR. The Jenkins slaves need the proper permissions so
+that they can assume the correct IAM role which has the right IAM policies to publish to ECR in another account. You 
+can assign the correct permissions that the Jenkins slave ECS tasks will use by executing the
+[CrossAccountSlaveRoles](CrossAccountSlaveRoles.yml) CloudFormation template. 
+
+#### ECR resides in the same account as Jenkins ####
+
+The Jenkins slaves (run as ECS tasks) will push Docker images to ECR and need the proper permissions in order to do 
+this. You can assign the correct permissions that the Jenkins slave ECS tasks will use by executing the 
+[LocalSlaveRoles](LocalSlaveRoles.yml) CloudFormation template.
  
 ## What is included
  

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Once an ECS cluster has been created with the linked template, the stack name sh
 
 The ECS cluster should also be using an EFS mount [EFS Mount Template](https://github.com/ukayani/ecs-cluster#efswithmounttargettemplate)
  
+The Jenkins slaves can be optimized to fetch cache data (eg. to avoid unnecessary network traffic especially for 
+Scala/SBT projects) and also push Docker images to ECR (which may not reside in the same account). You can enable these
+features by executing the [SlaveRoles](SlaveRoles.yml) CloudFormation template. 
+
+**Note:** that you need to specify the ARN for the IAM role that allows publishing Docker images to ECR to the 
+[SlaveRoles](SlaveRoles.yml) CloudFormation template. 
+ 
 ## What is included
  
 - Creation of a task/service to run Jenkins


### PR DESCRIPTION
- Add documentation 
- Support ECR being in the same account as Jenkins via a CloudFormation template
- Allow conditional setup of a Kinesis subscription filter
- Allow specifying a Docker image to use (default to `loyaltyone/jenkins`) for the Jenkins master
- Group CloudFormation parameters
- Feeding in additional parameters to Jenkins master in Task Definition to speed up slave provisioning (see [here](https://github.com/jenkinsci/amazon-ecs-plugin/pull/48#issuecomment-374554410) for more information)